### PR TITLE
docs: community roadmap, unified plugin strategy, industry workflow-pack template

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,185 @@
+# Roadmap
+
+> Last updated 2026-07-13. Maintained by [WYRE Technology](https://wyretechnology.com).
+> Live project board: [github.com/orgs/wyre-technology/projects/1](https://github.com/orgs/wyre-technology/projects/1)
+
+This document is the public strategy and roadmap for `msp-claude-plugins`. It says
+what we're committed to, where the project is going, and how releases work — so you
+can decide whether to build on it. Short version: you can.
+
+## Our commitment to this project
+
+**This repository is not being abandoned, wound down, or replaced.** It is the
+canonical community marketplace for MSP Claude Code plugins, and it stays that way.
+The community that formed around this repo — contributors, issue reporters, MSPs
+running these plugins in production — is the most valuable thing the project has
+built, and we intend to keep earning it.
+
+Concretely, that means a maintenance SLO for everything already shipped:
+
+| Commitment | Target |
+|---|---|
+| Marketplace stays installable | Every commit to `main` passes `claude plugin validate` in CI; `main` is branch-protected on that workflow |
+| Issue acknowledgment | Within 2 business days |
+| Regression in a shipped plugin (broken install, broken frontmatter) | Highest priority; fix targeted within 1 week |
+| Vendor API breakage | Production-tier plugins: fix or documented workaround targeted within 2 weeks. Beta/Alpha: best-effort, prioritized by reported usage |
+| Deprecation | Nothing disappears silently. A plugin is only removed after 90 days' notice in [CHANGELOG.md](CHANGELOG.md) and the README, and it remains installable through the notice window |
+| Changelog | Every user-visible change lands in [CHANGELOG.md](CHANGELOG.md) ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format) |
+
+Today the marketplace carries **63 plugins** — 300+ skills, 250+ slash commands,
+115+ subagents — across PSA, RMM, documentation, security, email security,
+monitoring, networking, accounting, CRM, and sales tooling. All of it is covered by
+the SLO above, whether it was written by WYRE or by a community contributor.
+
+## One marketplace, two consumers
+
+There is one repo and one catalog. It is consumed two ways, and both consume the
+exact same artifact — there is no fork, no parallel format, no "community edition."
+
+```
+              wyre-technology/msp-claude-plugins
+        one repo · one marketplace.json · one set of plugins
+                (skills, agents, commands, .mcp.json)
+                              │
+          ┌───────────────────┴───────────────────┐
+          │                                       │
+  Claude Code / Claude Desktop            Conduit (mcp.wyre.ai)
+  ──────────────────────────              ──────────────────────────
+  /plugin marketplace add                 Marketplace ingestion,
+    wyre-technology/msp-claude-plugins    pinned to a git SHA per sync
+  /plugin install <name>@msp-claude-plugins
+          │                                       │
+  plugins run locally: skills,            curated skills catalog with
+  agents, slash commands, and             org-level grants, automated
+  .mcp.json connections               security scanning, and audit
+                                          trails layered on top
+```
+
+- **Claude Code path** — the classic open-source flow. Add the marketplace, install
+  plugins, done. Free, no account, works offline once installed.
+- **Conduit path** — [Conduit](https://mcp.wyre.ai) syncs this repo into its
+  curated skills catalog (each sync pinned to an exact commit SHA). Organizations
+  get the same skills with governance on top: admins grant packs to teams, every
+  ingested skill passes automated security scanning before it's enabled, and usage
+  is auditable. WYRE's first-party plugins, skills, and subagents form the curated
+  tier inside the same catalog.
+
+The north star for both paths is the same: **dead simple**. One command (or one
+click) to enable a plugin or a pack — with Conduit adding the compliance and
+governance layer that MSP organizations need, not a different install experience.
+
+## What just shipped
+
+- **Official-format alignment** ([#136](https://github.com/wyre-technology/msp-claude-plugins/pull/136),
+  merged). The marketplace now validates clean against the official Claude Code
+  plugin-marketplace spec: real SchemaStore `$schema`, `plugin.json` as the sole
+  version authority, entry names aligned with plugin names, and a CI `Validate`
+  workflow with a drift check and a **version bump-gate** (see
+  [Versioning](#versioning-and-releases) below).
+- **Frontmatter modernization** ([#137](https://github.com/wyre-technology/msp-claude-plugins/pull/137),
+  in review). Every command, skill, and agent migrates to the official Claude Code
+  frontmatter formats — 252 commands, 301 skills, and a repo-wide fix for invalid
+  agent YAML. Once merged, per-plugin validation flips from advisory to hard-fail
+  in CI.
+- **Conduit marketplace ingestion** ([conduit#917](https://github.com/wyre-technology/conduit/pull/917),
+  in review). Conduit learns to load skills directly from an official Claude Code
+  plugin-marketplace repo — this one. Single pinned SHA per sync, pre-ingestion
+  security scanning, provenance recorded. This is what makes "one marketplace, two
+  consumers" real rather than aspirational.
+
+## Near term: industry workflow packs
+
+The next major addition to the catalog. Today's plugins are **vendor-shaped** — one
+plugin per tool, deep knowledge of that tool's API. Workflow packs are
+**job-shaped**: cross-vendor plugins that bundle the skills, subagents, and slash
+commands for how an MSP actually runs a function, wired to live systems through
+the WYRE MCP Gateway's connectors. Packs compose vendor plugins; they don't
+duplicate them.
+
+Packs ship continually as partners and integrations are added — each pack is a
+normal plugin in this marketplace, individually versioned, installable via
+`/plugin install <pack>@msp-claude-plugins` or enabled with one click in Conduit.
+
+The first four:
+
+### 1. MSP Operations (`ops-pack`)
+
+The daily service-desk engine: board health, dispatch, SLA pressure, handoffs.
+
+- **Skills:** `sla-escalation-playbooks`, `dispatch-prioritization`, `board-hygiene`
+- **Agents:** `board-health-auditor`, `stale-ticket-chaser`, `dispatch-coordinator`
+- **Commands:** `/ops-pack:morning-huddle`, `/ops-pack:sla-breaches`, `/ops-pack:eod-handoff`
+
+### 2. Security Operations (`secops-pack`)
+
+Cross-vendor alert triage and incident response across your EDR/MDR/SIEM stack
+(Huntress, Blackpoint, SentinelOne, Blumira, SaaS Alerts, CIPP — whatever is
+connected).
+
+- **Skills:** `alert-severity-normalization`, `containment-playbooks`, `bec-response`
+- **Agents:** `overnight-alert-summarizer`, `incident-timeline-builder`, `tenant-exposure-ranker`
+- **Commands:** `/secops-pack:portfolio-sweep`, `/secops-pack:incident-report`, `/secops-pack:tenant-exposure`
+
+### 3. Finance & Billing (`finance-pack`)
+
+Agreement and billing truth across PSA, accounting (QuickBooks Online, Xero), and
+distribution (Pax8, Sherweb).
+
+- **Skills:** `agreement-reconciliation`, `license-true-up`, `margin-analysis`
+- **Agents:** `billing-drift-detector`, `renewal-calendar-builder`, `profitability-ranker`
+- **Commands:** `/finance-pack:month-end-recon`, `/finance-pack:true-up`, `/finance-pack:renewals`
+
+### 4. Compliance (`compliance-pack`)
+
+Evidence collection and control drift against the frameworks MSP clients actually
+get asked about (CIS, SOC 2, HIPAA, cyber-insurance questionnaires), grounded in
+CIPP, Liongard, and IT Glue.
+
+- **Skills:** `evidence-mapping`, `standards-drift`, `insurance-questionnaires`
+- **Agents:** `evidence-packager`, `control-drift-reporter`, `questionnaire-autofiller`
+- **Commands:** `/compliance-pack:evidence-pack`, `/compliance-pack:drift-report`, `/compliance-pack:questionnaire`
+
+The pack anatomy — what's in one, the design rules, and the `.mcp.json` gateway
+wiring — is documented in the
+[workflow-pack template](msp-claude-plugins/_templates/workflow-pack-template/README.md).
+Names and contents above are the design targets; each pack lands via a normal PR
+with its own PRD, and the catalog grows from there as new partner integrations come
+online.
+
+## How to contribute
+
+Same as always — [CONTRIBUTING.md](CONTRIBUTING.md) has the full tiered guide:
+
+- **Tier 1 — quick fixes:** typos, field-mapping corrections, bug fixes. Fork,
+  branch, PR. No process.
+- **Tier 2 — enhancements:** new commands/skills for existing plugins. Open a
+  feature issue, get a maintainer thumbs-up, PR.
+- **Tier 3 — new platforms (and new workflow packs):** PRD first, from
+  `_templates/`. Community review, then build.
+
+Contributions that land here reach both consumers automatically: Claude Code users
+on their next `/plugin marketplace update`, and Conduit organizations on the next
+catalog sync. One PR, both audiences.
+
+Questions or ideas? [Discussions](https://github.com/wyre-technology/msp-claude-plugins/discussions)
+or [Discord](https://discord.gg/cCPtPaFw8e).
+
+## Versioning and releases
+
+- **Semver, per plugin.** Each plugin's `.claude-plugin/plugin.json` is the sole
+  version authority (marketplace entries carry no version fields as of #136).
+- **The bump-gate.** Claude Code's update detection is a version-string match —
+  pushing changes without bumping the version means installed users silently never
+  receive them. CI therefore fails any PR that changes files under a plugin's
+  directory without bumping that plugin's version. If CI is green, shipped means
+  shipped.
+- **Conventional commits** (`fix:`, `feat:`, `docs:`, …) on every PR; every
+  user-visible change is recorded in [CHANGELOG.md](CHANGELOG.md) under
+  [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
+- **Getting updates.** Claude Code: `/plugin marketplace update msp-claude-plugins`.
+  Conduit: catalog syncs are pinned to a commit SHA, so an org's catalog states
+  exactly which version of this repo it reflects.
+
+---
+
+Built by MSPs, for MSPs — and staying that way.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Last updated 2026-07-13. Maintained by [WYRE Technology](https://wyretechnology.com).
+> Last updated 2026-08-21. Maintained by [WYRE Technology](https://wyretechnology.com).
 > Live project board: [github.com/orgs/wyre-technology/projects/1](https://github.com/orgs/wyre-technology/projects/1)
 
 This document is the public strategy and roadmap for `msp-claude-plugins`. It says
@@ -22,7 +22,7 @@ by construction. Nothing is removed silently — deprecations are called out in
 user-visible change lands in [CHANGELOG.md](CHANGELOG.md) following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
 
-Today the marketplace carries **63 plugins** — 300+ skills, 250+ slash commands,
+Today the marketplace carries **81 plugins** — 300+ skills, 250+ slash commands,
 115+ subagents — across PSA, RMM, documentation, security, email security,
 monitoring, networking, accounting, CRM, and sales tooling. All of it is
 maintained under that same standard, whether it was written by WYRE or by a
@@ -74,12 +74,12 @@ governance layer that MSP organizations need, not a different install experience
   workflow with a drift check and a **version bump-gate** (see
   [Versioning](#versioning-and-releases) below).
 - **Frontmatter modernization** ([#137](https://github.com/wyre-technology/msp-claude-plugins/pull/137),
-  in review). Every command, skill, and agent migrates to the official Claude Code
+  merged). Every command, skill, and agent migrates to the official Claude Code
   frontmatter formats — 252 commands, 301 skills, and a repo-wide fix for invalid
-  agent YAML. Once merged, per-plugin validation flips from advisory to hard-fail
-  in CI.
+  agent YAML. Per-plugin validation in CI is still advisory pending a follow-up
+  cleanup pass, ahead of flipping to hard-fail.
 - **Conduit marketplace ingestion** ([conduit#917](https://github.com/wyre-technology/conduit/pull/917),
-  in review). Conduit learns to load skills directly from an official Claude Code
+  merged). Conduit learns to load skills directly from an official Claude Code
   plugin-marketplace repo — this one. Single pinned SHA per sync, pre-ingestion
   security scanning, provenance recorded. This is what makes "one marketplace, two
   consumers" real rather than aspirational.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,21 +15,18 @@ The community that formed around this repo — contributors, issue reporters, MS
 running these plugins in production — is the most valuable thing the project has
 built, and we intend to keep earning it.
 
-Concretely, that means a maintenance SLO for everything already shipped:
-
-| Commitment | Target |
-|---|---|
-| Marketplace stays installable | Every commit to `main` passes `claude plugin validate` in CI; `main` is branch-protected on that workflow |
-| Issue acknowledgment | Within 2 business days |
-| Regression in a shipped plugin (broken install, broken frontmatter) | Highest priority; fix targeted within 1 week |
-| Vendor API breakage | Production-tier plugins: fix or documented workaround targeted within 2 weeks. Beta/Alpha: best-effort, prioritized by reported usage |
-| Deprecation | Nothing disappears silently. A plugin is only removed after 90 days' notice in [CHANGELOG.md](CHANGELOG.md) and the README, and it remains installable through the notice window |
-| Changelog | Every user-visible change lands in [CHANGELOG.md](CHANGELOG.md) ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format) |
+Concretely: every commit to `main` passes `claude plugin validate` in CI, and
+`main` is branch-protected on that workflow, so the marketplace stays installable
+by construction. Nothing is removed silently — deprecations are called out in
+[CHANGELOG.md](CHANGELOG.md) and the README before a plugin disappears. Every
+user-visible change lands in [CHANGELOG.md](CHANGELOG.md) following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
 
 Today the marketplace carries **63 plugins** — 300+ skills, 250+ slash commands,
 115+ subagents — across PSA, RMM, documentation, security, email security,
-monitoring, networking, accounting, CRM, and sales tooling. All of it is covered by
-the SLO above, whether it was written by WYRE or by a community contributor.
+monitoring, networking, accounting, CRM, and sales tooling. All of it is
+maintained under that same standard, whether it was written by WYRE or by a
+community contributor.
 
 ## One marketplace, two consumers
 

--- a/msp-claude-plugins/_templates/workflow-pack-template/README.md
+++ b/msp-claude-plugins/_templates/workflow-pack-template/README.md
@@ -1,0 +1,212 @@
+# Industry Workflow Pack — anatomy and exemplar
+
+This is the design note for **industry workflow packs**: cross-vendor plugins that
+bundle the skills, subagents, and slash commands for how an MSP runs a whole
+function — operations, security ops, finance/billing, compliance — rather than for
+a single vendor's API. The roadmap context is in the repo-root
+[ROADMAP.md](../../../ROADMAP.md).
+
+This document is deliberately one file: it defines the structure and rules so the
+first pack PR (and every one after it) scaffolds against a settled shape. Do not
+copy this directory into a plugin; author the pack directory fresh and use the
+snippets below as the exemplar.
+
+## What a pack is (and is not)
+
+| | Vendor plugin (existing) | Workflow pack (new) |
+|---|---|---|
+| Shape | Tool-shaped: one vendor, deep API knowledge | Job-shaped: one MSP function, many vendors |
+| Skills teach | Endpoints, field mappings, rate limits | Playbooks, judgment calls, cross-system sequences |
+| Tools come from | The vendor's MCP server or the gateway | The WYRE MCP Gateway (`.mcp.json` below) |
+| Example | `autotask`, `huntress`, `quickbooks-online` | `ops-pack`, `secops-pack`, `finance-pack`, `compliance-pack` |
+
+Three hard rules:
+
+1. **Packs compose, never duplicate.** A pack must not restate vendor API knowledge
+   that lives in a vendor plugin's skills. If a pack needs Autotask status
+   semantics, its skill says "resolve status IDs via `autotask_list_ticket_statuses`" —
+   it does not re-document Autotask's status model. Duplicated knowledge drifts.
+2. **Ground every tool reference in the real gateway tool surface.** Agents and
+   commands name actual tools (`autotask_search_tickets`, `huntress_incidents_list`,
+   `cipp_list_tenants`). No invented tool names — this is what separates a pack
+   that works from marketing markdown.
+3. **Degrade explicitly.** Packs span vendors, but no MSP has every connector.
+   Every agent and command declares what it needs and what it does when a
+   connector is absent (skip the section and say so — never silently fabricate).
+
+## Exemplar structure: `ops-pack`
+
+Packs live under a `workflow-packs/` vendor-level directory inside the plugin
+root, one directory per pack, and are registered in `.claude-plugin/marketplace.json`
+like any other plugin:
+
+```
+msp-claude-plugins/workflow-packs/ops-pack/
+├── .claude-plugin/
+│   └── plugin.json               # name + version authority (bump-gate applies)
+├── README.md                     # what the pack runs, required/optional connectors
+├── .mcp.json                     # gateway wiring — see below
+├── skills/
+│   ├── sla-escalation-playbooks/SKILL.md
+│   ├── dispatch-prioritization/SKILL.md
+│   └── board-hygiene/SKILL.md
+├── agents/
+│   ├── board-health-auditor.md
+│   ├── stale-ticket-chaser.md
+│   └── dispatch-coordinator.md
+└── commands/
+    ├── morning-huddle.md         # → /ops-pack:morning-huddle
+    ├── sla-breaches.md           # → /ops-pack:sla-breaches
+    └── eod-handoff.md            # → /ops-pack:eod-handoff
+```
+
+### `plugin.json`
+
+```json
+{
+  "name": "ops-pack",
+  "displayName": "MSP Operations Pack",
+  "description": "Cross-vendor service-desk operations: board health, dispatch, SLA pressure, and shift handoffs across your connected PSA and RMM",
+  "version": "0.1.0",
+  "author": { "name": "MSP Claude Plugins Community" },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}
+```
+
+### Marketplace entry
+
+```json
+{
+  "name": "ops-pack",
+  "displayName": "MSP Operations Pack",
+  "source": "./msp-claude-plugins/workflow-packs/ops-pack",
+  "description": "Cross-vendor service-desk operations: board health, dispatch, SLA pressure, and shift handoffs",
+  "category": "workflow-pack",
+  "tags": ["workflow-pack", "operations", "msp", "cross-vendor"]
+}
+```
+
+`category: "workflow-pack"` is the discriminator both consumers use: the docs site
+groups packs separately from vendor plugins, and Conduit's catalog surfaces them as
+enable-in-one-click bundles.
+
+### `.mcp.json` — Conduit gateway wiring
+
+Packs are cross-vendor by definition, so they connect through the WYRE MCP Gateway
+(one authenticated connection, every connected vendor's tools) rather than to
+individual vendor MCP servers:
+
+```json
+{
+  "mcpServers": {
+    "msp-mcp-gateway": {
+      "type": "http",
+      "url": "https://mcp.wyre.ai/v1/mcp"
+    }
+  }
+}
+```
+
+This is the same wiring the `wyre-gateway` plugin ships. Installing a pack in
+Claude Code prompts the user to approve this server once; authentication is
+OAuth 2.1 + PKCE against the gateway, and which vendor tools actually appear is
+governed by the org's connected vendors and Conduit's org grants — the pack never
+carries credentials.
+
+Self-hosters can point the same pack at their own gateway URL; the pack's README
+must say so.
+
+### Skill exemplar (official frontmatter — matches `_templates/skill-template/`)
+
+```markdown
+---
+name: "SLA Escalation Playbooks"
+when_to_use: >-
+  When tickets are approaching or breaching SLA and the operator needs the
+  escalation sequence. Use when: SLA breach, escalation, response-time risk,
+  "what's about to breach".
+description: >
+  Use this skill when triaging SLA pressure across the connected PSA. Covers
+  breach-risk ordering, who gets paged at each escalation stage, and how to
+  post an escalation note the PSA's workflow rules will pick up. Resolve
+  status/priority IDs via the connected PSA's list tools (e.g.
+  autotask_list_ticket_statuses) — never hardcode tenant-specific IDs.
+---
+```
+
+Body sections follow the skill template: Overview, Key Concepts, Common Workflows,
+Error Handling. The pack-specific difference: a required **"Connected systems"**
+section listing which gateway connectors the skill draws on (required vs
+optional), and what changes when an optional one is missing.
+
+### Agent exemplar (official frontmatter — matches `_templates/agent-template.md`)
+
+```markdown
+---
+name: board-health-auditor
+description: Use this agent when a service manager needs a cross-board health
+  read - aging, unassigned, SLA-risk, and stale-ticket hotspots across the
+  connected PSA. Trigger for daily board reviews, "how's the board look",
+  pre-standup prep, and dispatch-load questions. Examples - "audit the board",
+  "what's rotting in the queue", "morning board health check"
+model: inherit
+---
+
+You are a service-desk operations analyst for an MSP. You ground yourself
+first: test the gateway connection, list the PSA's queues and statuses once,
+then pull open tickets ordered by SLA risk...
+```
+
+Agents follow the four-paragraph structure from the agent template (grounding,
+sequencing, reporting, variants) plus Capabilities and Approach sections. Pack
+agents additionally declare **required connectors** in their opening grounding
+paragraph and skip-with-a-note behavior for missing ones.
+
+### Command exemplar (official frontmatter — matches `_templates/command-template.md`)
+
+```markdown
+---
+description: Cross-system morning huddle - overnight alerts, board state, SLA risk, and today's schedule in one digest
+argument-hint: "[queue]"
+arguments: [queue]
+---
+
+# Morning Huddle
+
+## Prerequisites
+
+- WYRE MCP Gateway connected (`msp-mcp-gateway`) with at least a PSA connector
+- Optional: RMM, security connectors (sections are skipped with a note if absent)
+
+## Steps
+
+1. Verify gateway connectivity (call the PSA's test/ping tool)
+2. Pull overnight alerts from each connected security/RMM vendor
+3. Pull board state from the PSA (new, unassigned, SLA-risk), scoped to `queue` if given
+4. Emit the huddle digest: alerts → board → SLA risk → capacity flags
+
+## Arguments
+
+- `queue` (optional) — Limit the board section to one PSA queue/board
+```
+
+## Versioning and release
+
+Packs are plugins: semver in `plugin.json`, the CI bump-gate applies (any change
+under the pack directory without a version bump fails the PR), user-visible
+changes go in the repo [CHANGELOG.md](../../../CHANGELOG.md). Packs start at
+`0.1.0` and go `1.0.0` when every shipped agent/command has been exercised against
+a live gateway org.
+
+## Definition of done for a new pack
+
+- [ ] PRD submitted and approved (Tier 3 in [CONTRIBUTING.md](../../../CONTRIBUTING.md))
+- [ ] Every tool name verified against the live gateway tool surface
+- [ ] No duplicated vendor-plugin knowledge (composition rule above)
+- [ ] Explicit missing-connector behavior in every agent and command
+- [ ] `claude plugin validate <pack-dir>` clean
+- [ ] Marketplace entry with `category: "workflow-pack"`; drift check green
+- [ ] README lists required vs optional connectors and the self-hosted gateway note
+- [ ] Exercised end-to-end against a gateway org with a representative connector set

--- a/msp-claude-plugins/docs/src/components/Sidebar.astro
+++ b/msp-claude-plugins/docs/src/components/Sidebar.astro
@@ -49,6 +49,7 @@ const sidebarItems: SidebarItem[] = [
       { label: 'Introduction', href: `${baseUrl}getting-started/` },
       { label: 'Quick Start', href: `${baseUrl}getting-started/quick-start/` },
       { label: 'Installation', href: `${baseUrl}getting-started/installation/` },
+      { label: 'Roadmap', href: `${baseUrl}getting-started/roadmap/` },
     ]
   },
   {

--- a/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
@@ -1,0 +1,151 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Roadmap" description="Where MSP Claude Plugins and the WYRE MCP Gateway are headed: one marketplace consumed by Claude Code and Conduit, industry workflow packs, and one-click enablement with governance.">
+  <h1>Roadmap</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Where the platform is going, what just shipped, and what's next. The full
+    community-facing roadmap (including maintenance commitments and contribution
+    process) lives in the repository's
+    <a href="https://github.com/wyre-technology/msp-claude-plugins/blob/main/ROADMAP.md" target="_blank" rel="noopener noreferrer">ROADMAP.md</a>.
+  </p>
+
+  <h2>The commitment</h2>
+
+  <p>
+    The open-source marketplace — <strong>63 plugins</strong>, 300+ skills, 250+ slash
+    commands, 115+ subagents — is the canonical catalog, and it stays open and
+    maintained. Everything WYRE builds on top of it consumes that same catalog; there
+    is no separate "hosted edition" of the plugins. If you installed from GitHub two
+    releases ago, you're running the same content a Conduit-managed organization runs
+    today.
+  </p>
+
+  <p>
+    Every plugin in the catalog is covered by a published maintenance SLO: CI-enforced
+    installability on every commit, issue acknowledgment within two business days, and
+    a 90-day deprecation notice before anything is ever removed.
+  </p>
+
+  <h2>One marketplace, two ways to use it</h2>
+
+  <pre style="background: var(--code-bg, #1e1e2e); color: var(--code-text, #cdd6f4); padding: 1.5rem; border-radius: 0.5rem; overflow-x: auto; font-size: 0.9rem; line-height: 1.6;">
+              wyre-technology/msp-claude-plugins
+        one repo · one catalog · one set of plugins
+                            │
+        ┌───────────────────┴───────────────────┐
+        │                                       │
+Claude Code / Claude Desktop            Conduit (mcp.wyre.ai)
+────────────────────────────            ────────────────────────
+/plugin marketplace add …               curated skills catalog
+/plugin install &lt;name&gt;…                 synced from the marketplace,
+                                        pinned to an exact commit
+        │                                       │
+plugins run locally                     org grants · security
+                                        scanning · audit trails</pre>
+
+  <ul>
+    <li>
+      <strong>Claude Code / Claude Desktop</strong> — install straight from GitHub:
+      <code>/plugin marketplace add wyre-technology/msp-claude-plugins</code>, then
+      <code>/plugin install &lt;name&gt;@msp-claude-plugins</code>. Free, no account.
+      See <a href={`${baseUrl}getting-started/installation/`}>Installation</a>.
+    </li>
+    <li>
+      <strong>Conduit</strong> — the same catalog, delivered as a curated skills
+      library for your organization. Each sync is pinned to an exact commit of the
+      marketplace, every skill passes automated security scanning before it can be
+      enabled, admins grant packs to teams, and usage is auditable. See the
+      <a href={`${baseUrl}getting-started/gateway/`}>Gateway overview</a> and
+      <a href={`${baseUrl}getting-started/security/`}>Security Model</a>.
+    </li>
+  </ul>
+
+  <p>
+    The experience we're building toward is deliberately simple: <strong>one click (or
+    one command) to enable a plugin or a pack</strong> — with Conduit supplying the
+    compliance and governance layer MSP organizations need, rather than a different
+    install experience.
+  </p>
+
+  <h2>What just shipped</h2>
+
+  <ul>
+    <li>
+      <strong>Official plugin-format alignment.</strong> The marketplace now validates
+      clean against the official Claude Code plugin-marketplace spec, with CI that
+      guarantees any merged change actually reaches installed users (a version
+      bump-gate on every plugin change).
+    </li>
+    <li>
+      <strong>Conduit marketplace ingestion.</strong> Conduit loads its skills catalog
+      directly from this marketplace — single pinned commit per sync, pre-ingestion
+      security scanning, full provenance. One artifact, two consumers, now wired
+      end-to-end.
+    </li>
+    <li>
+      <strong>Advanced workflow guides.</strong> Twenty scheduled-routine guides built
+      and verified against live gateway connectors, from ticket triage to QBR prep —
+      see <a href={`${baseUrl}advanced-workflows/`}>Advanced Workflows</a>.
+    </li>
+  </ul>
+
+  <h2>Next: industry workflow packs</h2>
+
+  <p>
+    Today's plugins are vendor-shaped — one plugin per tool. The next wave is
+    <strong>job-shaped</strong>: workflow packs that bundle the skills, subagents, and
+    slash commands for how an MSP runs a whole function, across every vendor you have
+    connected to the gateway. Packs compose the vendor plugins; they don't duplicate
+    them. They release continually as new partner integrations come online.
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Pack</th>
+        <th>What it runs</th>
+        <th>Example contents</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>MSP Operations</strong></td>
+        <td>The daily service-desk engine: board health, dispatch, SLA pressure, shift handoffs</td>
+        <td><code>/ops-pack:morning-huddle</code>, <code>/ops-pack:sla-breaches</code>, a stale-ticket-chaser agent</td>
+      </tr>
+      <tr>
+        <td><strong>Security Operations</strong></td>
+        <td>Cross-vendor alert triage and incident response across your EDR/MDR/SIEM stack</td>
+        <td><code>/secops-pack:portfolio-sweep</code>, an overnight-alert-summarizer agent, containment playbooks</td>
+      </tr>
+      <tr>
+        <td><strong>Finance &amp; Billing</strong></td>
+        <td>Agreement and billing truth across PSA, accounting, and distribution</td>
+        <td><code>/finance-pack:month-end-recon</code>, <code>/finance-pack:true-up</code>, a billing-drift-detector agent</td>
+      </tr>
+      <tr>
+        <td><strong>Compliance</strong></td>
+        <td>Evidence collection and control drift against CIS, SOC 2, HIPAA, and insurance questionnaires</td>
+        <td><code>/compliance-pack:evidence-pack</code>, a control-drift-reporter agent, evidence-mapping skills</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    Each pack is a normal plugin in the marketplace: installable in Claude Code with
+    one command, enable-able in Conduit with one click, individually versioned, and
+    covered by the same maintenance SLO as everything else in the catalog.
+  </p>
+
+  <h2>Follow along</h2>
+
+  <ul>
+    <li><a href="https://github.com/orgs/wyre-technology/projects/1" target="_blank" rel="noopener noreferrer">Live project board</a> — what's in flight right now</li>
+    <li><a href="https://github.com/wyre-technology/msp-claude-plugins/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">Changelog</a> — every user-visible change, every release</li>
+    <li><a href="https://github.com/wyre-technology/msp-claude-plugins/discussions" target="_blank" rel="noopener noreferrer">Discussions</a> and <a href="https://discord.gg/cCPtPaFw8e" target="_blank" rel="noopener noreferrer">Discord</a> — tell us what your MSP needs next; workflow-pack priorities are driven by what operators ask for</li>
+  </ul>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
@@ -25,9 +25,10 @@ const baseUrl = import.meta.env.BASE_URL;
   </p>
 
   <p>
-    Every plugin in the catalog is covered by a published maintenance SLO: CI-enforced
-    installability on every commit, issue acknowledgment within two business days, and
-    a 90-day deprecation notice before anything is ever removed.
+    Every commit to the catalog passes automated validation before it lands, so
+    installability is enforced by CI rather than promised after the fact. Nothing is
+    removed silently — deprecations are announced in the changelog before a plugin
+    disappears.
   </p>
 
   <h2>One marketplace, two ways to use it</h2>
@@ -137,8 +138,8 @@ plugins run locally                     org grants · security
 
   <p>
     Each pack is a normal plugin in the marketplace: installable in Claude Code with
-    one command, enable-able in Conduit with one click, individually versioned, and
-    covered by the same maintenance SLO as everything else in the catalog.
+    one command, enable-able in Conduit with one click, and individually versioned
+    like everything else in the catalog.
   </p>
 
   <h2>Follow along</h2>

--- a/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/roadmap.astro
@@ -16,7 +16,7 @@ const baseUrl = import.meta.env.BASE_URL;
   <h2>The commitment</h2>
 
   <p>
-    The open-source marketplace — <strong>63 plugins</strong>, 300+ skills, 250+ slash
+    The open-source marketplace — <strong>81 plugins</strong>, 300+ skills, 250+ slash
     commands, 115+ subagents — is the canonical catalog, and it stays open and
     maintained. Everything WYRE builds on top of it consumes that same catalog; there
     is no separate "hosted edition" of the plugins. If you installed from GitHub two


### PR DESCRIPTION
## Summary

The public commitment piece of the marketplace work (#136/#137/#138 shipped the mechanics; this states the direction).

- **ROADMAP.md** — community-facing: explicit not-abandoned commitment with a maintenance SLO table, the one-marketplace/two-consumers architecture (Claude Code via `/plugin marketplace add`, Conduit via skills-catalog ingestion — conduit#917), what shipped, and the four planned **industry workflow packs** (ops-pack, secops-pack, finance-pack, compliance-pack) with named example skills/agents/commands.
- **docs roadmap page** for mcp.wyre.ai (customer-voiced, matches sibling Astro pages; one-line Sidebar.astro nav addition).
- **workflow-pack template design note** (`_templates/workflow-pack-template/README.md`) — one exemplar structure, not a 50-file scaffold: compose-don't-duplicate rule, real gateway tool names, explicit missing-connector degradation, frontmatter matching the post-#137 official formats.

## Review wanted on two things
1. **SLO numbers are proposals** (2-day issue ack, 1-week regression fix, 2-week Production-tier API-breakage fix, 90-day deprecation notice) — they become public commitments on merge.
2. **Pack naming** — `ops-pack`/`secops-pack`/`finance-pack`/`compliance-pack` become command namespaces (`/ops-pack:morning-huddle`); rename now or never.

## Verification
Astro build green (140 pages, roadmap emitted, nav renders); drift/bump-gate clean (0 plugins touched); relative links resolve.