### PR TITLE
fix: widen deploy-docs.yml push trigger to cover marketplace/scaffold changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'msp-claude-plugins/docs/**'
+      - '.claude-plugin/marketplace.json'
+      - 'msp-claude-plugins/**/.claude-plugin/plugin.json'
+      - 'msp-claude-plugins/**/README.md'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

`deploy-docs.yml`'s push trigger only watches `msp-claude-plugins/docs/**`. The same workflow also carries the `notify-gateway` job, which fires the `docs-updated` repository_dispatch that `wyre-technology/mcp-gateway`'s CI consumes to rebuild the gateway image with the current `marketplace.json` baked in.

Consequence: marketplace.json and plugin-scaffold changes (which the gateway image depends on) do not auto-trigger a gateway rebuild — only changes under `docs/**` do. PR #120 (marketplace.json + scaffolds) needed a manual `gh workflow run deploy-docs.yml` as a workaround.

## Fix

Extend the push path filter to also cover:
- `.claude-plugin/marketplace.json`
- `msp-claude-plugins/**/.claude-plugin/plugin.json`
- `msp-claude-plugins/**/README.md`

This is the path-filter fix shape proposed in the issue. Minimal, single-file change.

Fixes #121

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/msp-claude-plugins/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790469550&installation_model_id=431408&pr_number=226&repository=WYRE-AI%2Fmsp-claude-plugins&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fmsp-claude-plugins%2Fpull%2F226&signature=bd73ae2e340774ba4b21bb72d374a3396c49796b223a3dc3fcff7bca5d36e391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->