### PR TITLE
docs: update wyre-technology org refs to WYRE-AI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Just fork, branch, and open a PR.
 
 ### Tier 2 — Feature Enhancements (lightweight proposal)
 
-Open a [Feature Enhancement issue](https://github.com/wyre-technology/msp-claude-plugins/issues/new?template=feature-enhancement.yml) describing what you want to add. Get a maintainer thumbs-up, then submit a PR.
+Open a [Feature Enhancement issue](https://github.com/WYRE-AI/msp-claude-plugins/issues/new?template=feature-enhancement.yml) describing what you want to add. Get a maintainer thumbs-up, then submit a PR.
 
 **Examples:**
 - New commands for existing plugins
@@ -88,7 +88,7 @@ git clone https://github.com/YOUR-USERNAME/msp-claude-plugins.git
 cd msp-claude-plugins
 
 # 3. Add upstream remote for syncing
-git remote add upstream https://github.com/wyre-technology/msp-claude-plugins.git
+git remote add upstream https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # 4. Verify remotes
 git remote -v
@@ -603,8 +603,8 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 | Channel | Use Case |
 |---------|----------|
-| [GitHub Issues](https://github.com/wyre-technology/msp-claude-plugins/issues) | Bug reports, feature requests |
-| [GitHub Discussions](https://github.com/wyre-technology/msp-claude-plugins/discussions) | Questions, ideas, community chat |
+| [GitHub Issues](https://github.com/WYRE-AI/msp-claude-plugins/issues) | Bug reports, feature requests |
+| [GitHub Discussions](https://github.com/WYRE-AI/msp-claude-plugins/discussions) | Questions, ideas, community chat |
 | PR Comments | Code review, implementation questions |
 
 ### Getting API Access
@@ -636,6 +636,6 @@ We are committed to providing a welcoming and inclusive environment for all cont
 <p align="center">
   <strong>Questions?</strong> Open an issue or start a discussion.
   <br>
-  <a href="https://github.com/wyre-technology/msp-claude-plugins/issues">Issues</a> &bull;
-  <a href="https://github.com/wyre-technology/msp-claude-plugins/discussions">Discussions</a>
+  <a href="https://github.com/WYRE-AI/msp-claude-plugins/issues">Issues</a> &bull;
+  <a href="https://github.com/WYRE-AI/msp-claude-plugins/discussions">Discussions</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > One command to supercharge Claude Code for MSP workflows.
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 ```
 
 Then restart Claude Code. That's it.
@@ -58,39 +58,39 @@ Plus shared skills for MSP terminology, ticket triage, cross-vendor incident cor
 
 | Plugin | Status | MCP Server |
 |--------|--------|------------|
-| **Autotask PSA** | ✅ Production | [autotask-mcp](https://github.com/wyre-technology/autotask-mcp) |
-| **Datto RMM** | ✅ Production | [datto-rmm-mcp](https://github.com/wyre-technology/datto-rmm-mcp) |
-| **IT Glue** | ✅ Production | [itglue-mcp](https://github.com/wyre-technology/itglue-mcp) |
-| **Hudu** | 🔨 Beta | [hudu-mcp](https://github.com/wyre-technology/hudu-mcp) |
-| **RocketCyber** | 🔨 Beta | [rocketcyber-mcp](https://github.com/wyre-technology/rocketcyber-mcp) |
-| **Syncro** | 🔨 Beta | [syncro-mcp](https://github.com/wyre-technology/syncro-mcp) |
-| **Atera** | 🔨 Beta | [atera-mcp](https://github.com/wyre-technology/atera-mcp) |
-| **SuperOps.ai** | 🔨 Beta | [superops-mcp](https://github.com/wyre-technology/superops-mcp) |
-| **HaloPSA** | 🔨 Beta | [halopsa-mcp](https://github.com/wyre-technology/halopsa-mcp) |
-| **Liongard** | ✅ Production | [liongard-mcp](https://github.com/wyre-technology/liongard-mcp) |
-| **ConnectWise Manage** | 🔨 Beta | [connectwise-manage-mcp](https://github.com/wyre-technology/connectwise-manage-mcp) |
-| **ConnectWise Automate** | 🔨 Beta | [connectwise-automate-mcp](https://github.com/wyre-technology/connectwise-automate-mcp) |
-| **NinjaOne** | 🔨 Beta | [ninjaone-mcp](https://github.com/wyre-technology/ninjaone-mcp) |
-| **SalesBuildr** | 🚧 Alpha | [salesbuildr-mcp](https://github.com/wyre-technology/salesbuildr-mcp) |
+| **Autotask PSA** | ✅ Production | [autotask-mcp](https://github.com/WYRE-AI/autotask-mcp) |
+| **Datto RMM** | ✅ Production | [datto-rmm-mcp](https://github.com/WYRE-AI/datto-rmm-mcp) |
+| **IT Glue** | ✅ Production | [itglue-mcp](https://github.com/WYRE-AI/itglue-mcp) |
+| **Hudu** | 🔨 Beta | [hudu-mcp](https://github.com/WYRE-AI/hudu-mcp) |
+| **RocketCyber** | 🔨 Beta | [rocketcyber-mcp](https://github.com/WYRE-AI/rocketcyber-mcp) |
+| **Syncro** | 🔨 Beta | [syncro-mcp](https://github.com/WYRE-AI/syncro-mcp) |
+| **Atera** | 🔨 Beta | [atera-mcp](https://github.com/WYRE-AI/atera-mcp) |
+| **SuperOps.ai** | 🔨 Beta | [superops-mcp](https://github.com/WYRE-AI/superops-mcp) |
+| **HaloPSA** | 🔨 Beta | [halopsa-mcp](https://github.com/WYRE-AI/halopsa-mcp) |
+| **Liongard** | ✅ Production | [liongard-mcp](https://github.com/WYRE-AI/liongard-mcp) |
+| **ConnectWise Manage** | 🔨 Beta | [connectwise-manage-mcp](https://github.com/WYRE-AI/connectwise-manage-mcp) |
+| **ConnectWise Automate** | 🔨 Beta | [connectwise-automate-mcp](https://github.com/WYRE-AI/connectwise-automate-mcp) |
+| **NinjaOne** | 🔨 Beta | [ninjaone-mcp](https://github.com/WYRE-AI/ninjaone-mcp) |
+| **SalesBuildr** | 🚧 Alpha | [salesbuildr-mcp](https://github.com/WYRE-AI/salesbuildr-mcp) |
 | **Pax8** | ✅ Production | [Pax8 Hosted](https://mcp.pax8.com/v1/mcp) (official) |
-| **Xero** | 🔨 Beta | [xero-mcp](https://github.com/wyre-technology/xero-mcp) |
-| **QuickBooks Online** | 🔨 Beta | [qbo-mcp](https://github.com/wyre-technology/qbo-mcp) |
+| **Xero** | 🔨 Beta | [xero-mcp](https://github.com/WYRE-AI/xero-mcp) |
+| **QuickBooks Online** | 🔨 Beta | [qbo-mcp](https://github.com/WYRE-AI/qbo-mcp) |
 | **Microsoft 365** | 🔨 Beta | [ms-365-mcp-server](https://github.com/softeria/ms-365-mcp-server) (Softeria) |
 | **Rootly** | 🔨 Beta | [Rootly Hosted](https://mcp.rootly.com) (official) |
-| **Huntress** | 🔨 Beta | [huntress-mcp](https://github.com/wyre-technology/huntress-mcp) |
-| **Blumira** | 🔨 Beta | [blumira-mcp](https://github.com/wyre-technology/blumira-mcp) |
-| **SentinelOne** | 🔨 Beta | [sentinelone-mcp](https://github.com/wyre-technology/sentinelone-mcp) |
-| **Abnormal Security** | 🔨 Beta | [abnormal-mcp](https://github.com/wyre-technology/abnormal-mcp) |
-| **Avanan** | 🔨 Beta | [avanan-mcp](https://github.com/wyre-technology/avanan-mcp) |
-| **Ironscales** | 🔨 Beta | [ironscales-mcp](https://github.com/wyre-technology/ironscales-mcp) |
-| **Mimecast** | 🔨 Beta | [mimecast-mcp](https://github.com/wyre-technology/mimecast-mcp) |
-| **SpamTitan** | 🔨 Beta | [spamtitan-mcp](https://github.com/wyre-technology/spamtitan-mcp) |
-| **Proofpoint** | 🔨 Beta | [proofpoint-mcp](https://github.com/wyre-technology/proofpoint-mcp) |
-| **KnowBe4** | 🔨 Beta | [knowbe4-mcp](https://github.com/wyre-technology/knowbe4-mcp) |
-| **HubSpot** | 🔨 Beta | [hubspot-mcp](https://github.com/wyre-technology/hubspot-mcp) |
-| **PandaDoc** | 🔨 Beta | [pandadoc-mcp](https://github.com/wyre-technology/pandadoc-mcp) |
-| **BetterStack** | 🔨 Beta | [betterstack-mcp](https://github.com/wyre-technology/betterstack-mcp) |
-| **PagerDuty** | 🔨 Beta | [pagerduty-mcp](https://github.com/wyre-technology/pagerduty-mcp) |
+| **Huntress** | 🔨 Beta | [huntress-mcp](https://github.com/WYRE-AI/huntress-mcp) |
+| **Blumira** | 🔨 Beta | [blumira-mcp](https://github.com/WYRE-AI/blumira-mcp) |
+| **SentinelOne** | 🔨 Beta | [sentinelone-mcp](https://github.com/WYRE-AI/sentinelone-mcp) |
+| **Abnormal Security** | 🔨 Beta | [abnormal-mcp](https://github.com/WYRE-AI/abnormal-mcp) |
+| **Avanan** | 🔨 Beta | [avanan-mcp](https://github.com/WYRE-AI/avanan-mcp) |
+| **Ironscales** | 🔨 Beta | [ironscales-mcp](https://github.com/WYRE-AI/ironscales-mcp) |
+| **Mimecast** | 🔨 Beta | [mimecast-mcp](https://github.com/WYRE-AI/mimecast-mcp) |
+| **SpamTitan** | 🔨 Beta | [spamtitan-mcp](https://github.com/WYRE-AI/spamtitan-mcp) |
+| **Proofpoint** | 🔨 Beta | [proofpoint-mcp](https://github.com/WYRE-AI/proofpoint-mcp) |
+| **KnowBe4** | 🔨 Beta | [knowbe4-mcp](https://github.com/WYRE-AI/knowbe4-mcp) |
+| **HubSpot** | 🔨 Beta | [hubspot-mcp](https://github.com/WYRE-AI/hubspot-mcp) |
+| **PandaDoc** | 🔨 Beta | [pandadoc-mcp](https://github.com/WYRE-AI/pandadoc-mcp) |
+| **BetterStack** | 🔨 Beta | [betterstack-mcp](https://github.com/WYRE-AI/betterstack-mcp) |
+| **PagerDuty** | 🔨 Beta | [pagerduty-mcp](https://github.com/WYRE-AI/pagerduty-mcp) |
 
 > Maturity levels: ✅ **Production** — used in real MSP environments with comprehensive coverage. 🔨 **Beta** — functional with core features, feedback welcome. 🚧 **Alpha** — early implementation, expect gaps.
 
@@ -111,13 +111,13 @@ claude mcp add --transport http msp-mcp-gateway https://conduit.wyre.ai/v1/mcp
 **Claude Desktop (macOS / Linux):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wyre-technology/msp-claude-plugins/main/msp-claude-plugins/wyre-gateway/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/WYRE-AI/msp-claude-plugins/main/msp-claude-plugins/wyre-gateway/install.sh | bash
 ```
 
 **Claude Desktop (Windows):**
 
 ```powershell
-irm https://raw.githubusercontent.com/wyre-technology/msp-claude-plugins/main/msp-claude-plugins/wyre-gateway/install.ps1 | iex
+irm https://raw.githubusercontent.com/WYRE-AI/msp-claude-plugins/main/msp-claude-plugins/wyre-gateway/install.ps1 | iex
 ```
 
 The installer scripts preserve your existing config, create a backup, and only append the gateway entry.
@@ -167,7 +167,7 @@ and benefit from familiarity with the vendor's API.
 Want just one vendor? Add the marketplace once, then install plugins individually:
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install autotask@msp-claude-plugins
 /plugin install syncro@msp-claude-plugins
 /plugin install halopsa@msp-claude-plugins
@@ -180,7 +180,7 @@ This PR adds Codex metadata for the Autotask plugin as a first representative
 pattern for cross-harness distribution:
 
 ```bash
-codex plugin marketplace add https://github.com/wyre-technology/msp-claude-plugins
+codex plugin marketplace add https://github.com/WYRE-AI/msp-claude-plugins
 ```
 
 Then install **Kaseya Autotask** from the Codex Plugins UI. The same
@@ -240,8 +240,8 @@ arguments, credentials, browser captures, or model outputs.
 This project is maintained by [WYRE AI](https://wyretechnology.com), a Chattanooga-based
 MSP focused on AI enablement.
 
-- **Questions or feedback?** Open a [Discussion](https://github.com/wyre-technology/msp-claude-plugins/discussions)
-- **Found a bug?** File an [Issue](https://github.com/wyre-technology/msp-claude-plugins/issues)
+- **Questions or feedback?** Open a [Discussion](https://github.com/WYRE-AI/msp-claude-plugins/discussions)
+- **Found a bug?** File an [Issue](https://github.com/WYRE-AI/msp-claude-plugins/issues)
 - **Want to contribute?** See [CONTRIBUTING.md](CONTRIBUTING.md)
 - **Using this in your MSP?** We'd love to hear about it — drop us a note in Discussions
 

--- a/msp-claude-plugins/README.md
+++ b/msp-claude-plugins/README.md
@@ -18,7 +18,7 @@ Community-driven Claude Code plugins for Managed Service Providers.
 ## Quick Start
 
 ```bash
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 ```
 
 ## Available Plugins
@@ -54,7 +54,7 @@ docker run -p 8080:8080 \
   -e MCP_TRANSPORT=http \
   -e AUTH_MODE=env \
   -e VENDOR_API_KEY=your-key \
-  ghcr.io/wyre-technology/{vendor}-mcp:latest
+  ghcr.io/WYRE-AI/{vendor}-mcp:latest
 ```
 
 ### Cloud deployment
@@ -63,7 +63,7 @@ Each MCP server includes configs for:
 - **Cloudflare Workers** — `wrangler.json` in each repo
 - **DigitalOcean App Platform** — `.do/app.yaml` in each repo
 
-See the [deployment docs](https://wyre-technology.github.io/msp-claude-plugins/deployment/) for full guides.
+See the [deployment docs](https://wyre-ai.github.io/msp-claude-plugins/deployment/) for full guides.
 
 ## Commands (71 total)
 
@@ -218,7 +218,7 @@ Each plugin requires API credentials. See the individual plugin READMEs for conf
 
 ## Documentation
 
-Full documentation: [https://wyre-technology.github.io/msp-claude-plugins/](https://wyre-technology.github.io/msp-claude-plugins/)
+Full documentation: [https://wyre-ai.github.io/msp-claude-plugins/](https://wyre-ai.github.io/msp-claude-plugins/)
 
 ## Contributing
 

--- a/msp-claude-plugins/_templates/governance-template.md
+++ b/msp-claude-plugins/_templates/governance-template.md
@@ -6,9 +6,9 @@
 > developer. Delete this blockquote.
 >
 > Every claim in a governance document must be checkable against
-> Conduit's source (`wyre-technology/conduit`), which is what serves
+> Conduit's source (`WYRE-AI/conduit`), which is what serves
 > `conduit.wyre.ai` — the endpoint every plugin's `.mcp.json` points at.
-> Do **not** verify against `wyre-technology/mcp-gateway`: that is a
+> Do **not** verify against `WYRE-AI/mcp-gateway`: that is a
 > separate repository serving `mcp.wyre.ai`, and the two have drifted.
 > `wyre-gateway/GOVERNANCE.md` substantiates every claim below,
 > including the places where it does not hold.

--- a/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "abnormal-security",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Claude plugins for Abnormal Security - AI-powered email security, threat detection, abuse mailbox cases, message and header forensics, and per-message remediation for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/abnormal/abnormal-security/README.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/README.md
@@ -53,7 +53,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `ABNORMAL_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `ABNORMAL_MCP_URL` to your gateway's endpoint:
 
 ```
 ABNORMAL_MCP_URL=https://your-gateway-domain/v1/abnormal-security/mcp

--- a/msp-claude-plugins/assets-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/assets-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "assets-pack",
   "displayName": "IT Asset Lifecycle",
   "description": "Cross-vendor IT asset lifecycle management \u2014 warranty tracking, end-of-life/end-of-support flagging, and hardware refresh-cycle planning across whatever RMM platforms and documentation tools you have connected.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/assets-pack/README.md
+++ b/msp-claude-plugins/assets-pack/README.md
@@ -132,7 +132,7 @@ directly.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install assets-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atera",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Claude Code plugin for Atera RMM/PSA - tickets, agents, customers, alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/atera/atera/README.md
+++ b/msp-claude-plugins/atera/atera/README.md
@@ -59,7 +59,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `ATERA_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `ATERA_MCP_URL` to your gateway's endpoint:
 
 ```
 ATERA_MCP_URL=https://your-gateway-domain/v1/atera/mcp
@@ -91,7 +91,7 @@ curl -s "https://app.atera.com/api/v3/customers" \
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/atera/atera

--- a/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auvik",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude plugins for Auvik - network monitoring, device inventory, alert triage, configuration audit, and capacity planning for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/auvik/auvik/README.md
+++ b/msp-claude-plugins/auvik/auvik/README.md
@@ -20,10 +20,10 @@ Auvik is a SaaS network monitoring and management product used by MSPs to discov
 
 ## Installation
 
-Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technology/msp-claude-plugins):
+Install via the [MSP Claude Plugins marketplace](https://github.com/WYRE-AI/msp-claude-plugins):
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install auvik
 ```
 

--- a/msp-claude-plugins/awareness-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/awareness-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "awareness-pack",
   "displayName": "Security Awareness & Training",
   "description": "Cross-vendor security awareness operations \u2014 training completion tracking, phishing simulation results, and per-user risk scoring across whatever security-awareness training tools you have connected. Complements secops-pack's technical threat response with the human-layer prevention side.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/awareness-pack/README.md
+++ b/msp-claude-plugins/awareness-pack/README.md
@@ -106,7 +106,7 @@ isolation.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install awareness-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/axcient/axcient/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/axcient/axcient/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axcient",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude plugins for Axcient x360Recover - clients, devices, backup jobs, vaults, and appliances for BCDR operations",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/axcient/axcient/README.md
+++ b/msp-claude-plugins/axcient/axcient/README.md
@@ -41,7 +41,7 @@ export AXCIENT_API_KEY="your-api-key"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `AXCIENT_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `AXCIENT_MCP_URL` to your gateway's endpoint:
 
 ```
 AXCIENT_MCP_URL=https://your-gateway-domain/v1/axcient/mcp

--- a/msp-claude-plugins/backup-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/backup-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "backup-pack",
   "displayName": "Backup & DR Assurance",
   "description": "Cross-vendor backup and disaster-recovery assurance \u2014 job health monitoring, restore-test verification, retention/RPO compliance, and DR readiness across whatever backup and BCDR tools you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/backup-pack/README.md
+++ b/msp-claude-plugins/backup-pack/README.md
@@ -118,7 +118,7 @@ single-vendor plugin directly.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install backup-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betterstack",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude plugins for Better Stack - uptime monitoring, incident management, status pages, on-call schedules, and log management (Logtail) for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/betterstack/betterstack/README.md
+++ b/msp-claude-plugins/betterstack/betterstack/README.md
@@ -36,7 +36,7 @@ export BETTERSTACK_API_TOKEN="your-api-token"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `BETTERSTACK_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `BETTERSTACK_MCP_URL` to your gateway's endpoint:
 
 ```
 BETTERSTACK_MCP_URL=https://your-gateway-domain/v1/betterstack/mcp

--- a/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blackpoint",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Blackpoint Cyber / CompassOne MDR - tenant, asset, detection, and vulnerability data for MSP incident response",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/blackpoint/blackpoint/README.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/README.md
@@ -17,7 +17,7 @@ Claude Code plugin for [Blackpoint Cyber](https://blackpointcyber.com) (the Comp
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install blackpoint
 ```
 

--- a/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blumira",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Claude plugins for Blumira - SIEM findings management, device inventory, MSP multi-tenant operations, and security posture analysis",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/blumira/blumira/README.md
+++ b/msp-claude-plugins/blumira/blumira/README.md
@@ -40,7 +40,7 @@ export BLUMIRA_JWT_TOKEN="your-jwt-token"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `BLUMIRA_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `BLUMIRA_MCP_URL` to your gateway's endpoint:
 
 ```
 BLUMIRA_MCP_URL=https://your-gateway-domain/v1/blumira/mcp

--- a/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cipp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude plugins for CIPP (CyberDrain Improved Partner Portal) \u2014 Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/cipp/cipp/README.md
+++ b/msp-claude-plugins/cipp/cipp/README.md
@@ -2,7 +2,7 @@
 
 Claude plugins for **CIPP (CyberDrain Improved Partner Portal)** — the open-source Microsoft 365 multi-tenant management platform widely used by MSPs.
 
-This plugin orients Claude around the [`cipp-mcp`](https://github.com/wyre-technology/cipp-mcp) server, which exposes ~37 typed tools across the CIPP REST API. Skills and agents in this plugin embed MSP workflow knowledge: how to onboard a tenant, drive a Secure Score review, run an offboarding sequence, and detect standards drift across a portfolio.
+This plugin orients Claude around the [`cipp-mcp`](https://github.com/WYRE-AI/cipp-mcp) server, which exposes ~37 typed tools across the CIPP REST API. Skills and agents in this plugin embed MSP workflow knowledge: how to onboard a tenant, drive a Secure Score review, run an offboarding sequence, and detect standards drift across a portfolio.
 
 ## What's in this plugin
 
@@ -34,7 +34,7 @@ This plugin orients Claude around the [`cipp-mcp`](https://github.com/wyre-techn
 
 ## Setup
 
-1. Stand up the [cipp-mcp](https://github.com/wyre-technology/cipp-mcp) server (Docker, npx, or Smithery).
+1. Stand up the [cipp-mcp](https://github.com/WYRE-AI/cipp-mcp) server (Docker, npx, or Smithery).
 2. Issue API credentials in CIPP at **Settings → API Client Management**.
 3. Copy `.env.example` to `.env` and fill in `CIPP_BASE_URL` plus either a bearer token or OAuth client-credentials.
    `CIPP_BASE_URL` must be the CIPP-API **Azure Function App** URL (`https://<function-app-name>.azurewebsites.net`, named like `cippXXXXX` in your CIPP resource group) — **not** the Static Web App / custom-domain UI URL. The SWA redirects bearer-token requests to its interactive login page, so API calls fail.
@@ -55,5 +55,5 @@ If you connect through the [Wyre MCP Gateway](https://conduit.wyre.ai), CIPP too
 
 - CIPP project: https://docs.cipp.app
 - CIPP API docs: https://docs.cipp.app/api-documentation/endpoints
-- cipp-mcp server: https://github.com/wyre-technology/cipp-mcp
+- cipp-mcp server: https://github.com/WYRE-AI/cipp-mcp
 - CIPP repo: https://github.com/KelvinTegelaar/CIPP

--- a/msp-claude-plugins/clio/clio/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/clio/clio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Clio Manage \u2014 legal practice management: matters, contacts, time/expense activities, tasks, documents (metadata), calendar, and billing.",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/clio/clio/README.md
+++ b/msp-claude-plugins/clio/clio/README.md
@@ -74,7 +74,7 @@ you to Clio directly, rather than attempting a workaround.
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install clio@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/cloudops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/cloudops-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "cloudops-pack",
   "displayName": "Cloud & Network Infrastructure",
   "description": "Cross-vendor network and cloud infrastructure operations \u2014 device/network health, capacity planning, and cost management across whatever network monitoring (Auvik, Meraki, Domotz) and cloud platforms (Azure, DigitalOcean) you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/cloudops-pack/README.md
+++ b/msp-claude-plugins/cloudops-pack/README.md
@@ -104,7 +104,7 @@ you have connected into one normalized view.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install cloudops-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/compliance-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/compliance-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "compliance-pack",
   "displayName": "Compliance",
   "description": "Cross-vendor compliance evidence collection and control drift detection \u2014 maps live tenant configuration and documentation to CIS/SOC 2/HIPAA controls and cyber-insurance questionnaire line items.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/compliance-pack/README.md
+++ b/msp-claude-plugins/compliance-pack/README.md
@@ -25,7 +25,7 @@ This pack connects through the [Conduit](https://conduit.wyre.ai) gateway — on
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install compliance-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/connectwise/automate/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/connectwise/automate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-automate",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Claude plugins for ConnectWise Automate RMM - computers, scripts, monitors, alerts, and client management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/connectwise/automate/README.md
+++ b/msp-claude-plugins/connectwise/automate/README.md
@@ -57,7 +57,7 @@ export CONNECTWISE_AUTOMATE_2FA="optional-2fa-key"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `CONNECTWISE_AUTOMATE_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `CONNECTWISE_AUTOMATE_MCP_URL` to your gateway's endpoint:
 
 ```
 CONNECTWISE_AUTOMATE_MCP_URL=https://your-gateway-domain/v1/connectwise-automate/mcp

--- a/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-cpq",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Claude Code plugin for ConnectWise CPQ (formerly Sell / Quosal) - quotes, line items, templates, quote customers, and payment terms",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/connectwise/cpq/README.md
+++ b/msp-claude-plugins/connectwise/cpq/README.md
@@ -20,7 +20,7 @@ products or agreements.
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install connectwise-cpq
 ```
 

--- a/msp-claude-plugins/connectwise/manage/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/connectwise/manage/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-psa",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Claude Code plugin for ConnectWise PSA (Manage) - tickets, companies, contacts, projects, and time tracking",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/connectwise/manage/README.md
+++ b/msp-claude-plugins/connectwise/manage/README.md
@@ -57,7 +57,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `CONNECTWISE_MANAGE_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `CONNECTWISE_MANAGE_MCP_URL` to your gateway's endpoint:
 
 ```
 CONNECTWISE_MANAGE_MCP_URL=https://your-gateway-domain/v1/connectwise-manage/mcp

--- a/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crewhu",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Crewhu - CSAT/NPS surveys, employee recognition, badges, and prize/redemption gamification for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/crewhu/crewhu/README.md
+++ b/msp-claude-plugins/crewhu/crewhu/README.md
@@ -12,7 +12,7 @@ Claude Code plugin for [Crewhu](https://crewhu.com) - CSAT/NPS surveys, recognit
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install crewhu
 ```
 

--- a/msp-claude-plugins/devops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/devops-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "devops-pack",
   "displayName": "DevOps & Reliability",
   "description": "Cross-vendor engineering reliability operations \u2014 on-call handoffs, incident postmortems, deploy health, and error-budget tracking across whatever incident-management, observability, and platform tools you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/devops-pack/README.md
+++ b/msp-claude-plugins/devops-pack/README.md
@@ -102,7 +102,7 @@ retrospective once it's contained.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install devops-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/docs/README.md
+++ b/msp-claude-plugins/docs/README.md
@@ -59,6 +59,6 @@ Plugin data is defined in `src/data/plugins.ts` and sourced from the plugin READ
 
 ## Deployment
 
-The site is deployed to GitHub Pages at `https://wyre-technology.github.io/msp-claude-plugins/`.
+The site is deployed to GitHub Pages at `https://wyre-ai.github.io/msp-claude-plugins/`.
 
 Build output goes to `dist/` directory.

--- a/msp-claude-plugins/docs/superpowers/plans/2026-07-07-docs-findability.md
+++ b/msp-claude-plugins/docs/superpowers/plans/2026-07-07-docs-findability.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- **Repo/paths:** All files are under `msp-claude-plugins/docs/` in the `wyre-technology/msp-claude-plugins` repo. Work on branch `docs/surface-connections-security-anchors` (already created off `origin/main`; the spec is already committed on it).
+- **Repo/paths:** All files are under `msp-claude-plugins/docs/` in the `WYRE-AI/msp-claude-plugins` repo. Work on branch `docs/surface-connections-security-anchors` (already created off `origin/main`; the spec is already committed on it).
 - **No new dependencies**, no `astro.config` changes, no route renames (`/plugins/` stays `/plugins/`).
 - **Internal links** use `baseUrl` (`const baseUrl = import.meta.env.BASE_URL`) — never hardcode a leading `/`, because `BASE_PATH` is `/` for the standalone build and `/docs/` for the gateway-embedded build.
 - **Runtime deep-links** (the anchor script) use `location.pathname` so they are correct under both base paths.

--- a/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
+++ b/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-19
 **Status:** Approved design (revised after gateway probe) — ready for implementation plan
-**Affects:** `wyre-technology/msp-claude-plugins` (Advanced Workflows docs + live routine)
+**Affects:** `WYRE-AI/msp-claude-plugins` (Advanced Workflows docs + live routine)
 
 ## Summary
 
@@ -61,7 +61,7 @@ problem worth surfacing weekly.
 
 ## Scope of changes
 
-Four artifacts change in `wyre-technology/msp-claude-plugins`:
+Four artifacts change in `WYRE-AI/msp-claude-plugins`:
 
 | Artifact | Change |
 |---|---|

--- a/msp-claude-plugins/docs/superpowers/specs/2026-07-07-docs-findability-design.md
+++ b/msp-claude-plugins/docs/superpowers/specs/2026-07-07-docs-findability-design.md
@@ -1,7 +1,7 @@
 # Docs Findability: Connections, Security & Anchor Links
 
 **Date:** 2026-07-07
-**Repo:** `wyre-technology/msp-claude-plugins` (builds the docs site at https://mcp.wyre.ai from `msp-claude-plugins/docs/`)
+**Repo:** `WYRE-AI/msp-claude-plugins` (builds the docs site at https://mcp.wyre.ai from `msp-claude-plugins/docs/`)
 **Branch:** `docs/surface-connections-security-anchors`
 
 ## Problem

--- a/msp-claude-plugins/domotz/domotz/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/domotz/domotz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "domotz",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Claude plugins for Domotz - network monitoring & management, device inventory, alert profile coverage, SNMP metrics, network topology, and PDU outlet control for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/domotz/domotz/README.md
+++ b/msp-claude-plugins/domotz/domotz/README.md
@@ -42,7 +42,7 @@ export DOMOTZ_REGION="us-east-1"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `DOMOTZ_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `DOMOTZ_MCP_URL` to your gateway's endpoint:
 
 ```
 DOMOTZ_MCP_URL=https://your-gateway-domain/v1/domotz/mcp

--- a/msp-claude-plugins/email-security/checkpoint-avanan/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "avanan",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Claude plugins for Checkpoint Harmony Email & Collaboration (Avanan) - email security, threat detection, quarantine actions, sender exceptions",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/checkpoint-avanan/README.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/README.md
@@ -52,7 +52,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `CHECKPOINT_AVANAN_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `CHECKPOINT_AVANAN_MCP_URL` to your gateway's endpoint:
 
 ```
 CHECKPOINT_AVANAN_MCP_URL=https://your-gateway-domain/v1/checkpoint-avanan/mcp

--- a/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowbe4",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude plugins for KnowBe4 - security awareness training, phishing simulation, user risk management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/knowbe4/README.md
+++ b/msp-claude-plugins/email-security/knowbe4/README.md
@@ -47,7 +47,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `KNOWBE4_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `KNOWBE4_MCP_URL` to your gateway's endpoint:
 
 ```
 KNOWBE4_MCP_URL=https://your-gateway-domain/v1/knowbe4/mcp

--- a/msp-claude-plugins/email-security/proofpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/proofpoint/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proofpoint",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude plugins for Proofpoint Email Protection - TAP, quarantine, threat intelligence, forensics, URL defense",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/proofpoint/README.md
+++ b/msp-claude-plugins/email-security/proofpoint/README.md
@@ -87,7 +87,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `PROOFPOINT_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `PROOFPOINT_MCP_URL` to your gateway's endpoint:
 
 ```
 PROOFPOINT_MCP_URL=https://your-gateway-domain/v1/proofpoint/mcp

--- a/msp-claude-plugins/finance-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/finance-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "finance-pack",
   "displayName": "Finance & Billing",
   "description": "Cross-vendor billing and agreement reconciliation \u2014 matches PSA contracts against accounting invoices and cloud-marketplace subscriptions, catches license true-up gaps, and ranks client profitability.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/finance-pack/README.md
+++ b/msp-claude-plugins/finance-pack/README.md
@@ -56,7 +56,7 @@ typically runs both.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install finance-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Freshdesk - cloud helpdesk/PSA ticketing for MSPs: tickets, conversations, contacts, companies, knowledge base, SLA policies, and business hours",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/freshdesk/freshdesk/README.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/README.md
@@ -12,7 +12,7 @@ Claude Code plugin for [Freshdesk](https://www.freshworks.com/freshdesk/) - clou
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install freshdesk
 ```
 

--- a/msp-claude-plugins/halopsa/halopsa/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/halopsa/halopsa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "halopsa",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude Code plugin for HaloPSA - tickets, clients, assets, contracts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/halopsa/halopsa/README.md
+++ b/msp-claude-plugins/halopsa/halopsa/README.md
@@ -52,7 +52,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `HALOPSA_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `HALOPSA_MCP_URL` to your gateway's endpoint:
 
 ```
 HALOPSA_MCP_URL=https://your-gateway-domain/v1/halopsa/mcp
@@ -131,7 +131,7 @@ curl -s "https://${HALOPSA_TENANT}.halopsa.com/api/Tickets?count=1" \
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/halopsa/halopsa

--- a/msp-claude-plugins/hudu/hudu/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/hudu/hudu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hudu",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude plugins for Hudu documentation platform - companies, assets, articles, passwords, websites",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/hudu/hudu/README.md
+++ b/msp-claude-plugins/hudu/hudu/README.md
@@ -40,7 +40,7 @@ export HUDU_API_KEY="your-api-key-here"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `HUDU_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `HUDU_MCP_URL` to your gateway's endpoint:
 
 ```
 HUDU_MCP_URL=https://your-gateway-domain/v1/hudu/mcp

--- a/msp-claude-plugins/huntress/huntress/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/huntress/huntress/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huntress",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Claude plugins for Huntress - managed threat detection, incident response, endpoint agent management, escalations, and billing reports for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/huntress/huntress/README.md
+++ b/msp-claude-plugins/huntress/huntress/README.md
@@ -38,7 +38,7 @@ export HUNTRESS_API_SECRET="your-api-secret"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `HUNTRESS_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `HUNTRESS_MCP_URL` to your gateway's endpoint:
 
 ```
 HUNTRESS_MCP_URL=https://your-gateway-domain/v1/huntress/mcp

--- a/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immybot",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, and script execution for MSPs (Entra ID OAuth)",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/immybot/immybot/README.md
+++ b/msp-claude-plugins/immybot/immybot/README.md
@@ -14,7 +14,7 @@ Claude Code plugin for [ImmyBot](https://immy.bot) - desired-state Windows softw
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install immybot
 ```
 

--- a/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inforcer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Inforcer - read-only Microsoft 365 security baseline governance for MSPs: tenants, baselines, alignment/drift, secure scores, identity inventory, audit events, and assessments",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/inforcer/inforcer/README.md
+++ b/msp-claude-plugins/inforcer/inforcer/README.md
@@ -44,7 +44,7 @@ These capabilities exist in the Inforcer product UI but are **not exposed throug
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install inforcer
 ```
 

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaseya-quote-manager",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Kaseya Quote Manager (Datto Commerce) - read-only access to quotes, sales orders, purchasing, catalog, CRM, and org data",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/README.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/README.md
@@ -7,7 +7,7 @@ distribution workflows.
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins --plugin kaseya-quote-manager
+/plugin marketplace add WYRE-AI/msp-claude-plugins --plugin kaseya-quote-manager
 ```
 
 ## Configuration

--- a/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autotask",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Claude plugins for Kaseya Autotask PSA - tickets, CRM, projects, contracts, expenses, quotes, quote builder",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/autotask/README.md
+++ b/msp-claude-plugins/kaseya/autotask/README.md
@@ -55,7 +55,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `AUTOTASK_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `AUTOTASK_MCP_URL` to your gateway's endpoint:
 
 ```
 AUTOTASK_MCP_URL=https://your-gateway-domain/v1/autotask/mcp

--- a/msp-claude-plugins/kaseya/datto-rmm/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-rmm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-rmm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Claude plugins for Datto RMM - devices, alerts, sites, jobs, remote monitoring",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/datto-rmm/README.md
+++ b/msp-claude-plugins/kaseya/datto-rmm/README.md
@@ -43,7 +43,7 @@ export DATTO_PLATFORM="merlot"  # Your platform
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `DATTO_RMM_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `DATTO_RMM_MCP_URL` to your gateway's endpoint:
 
 ```
 DATTO_RMM_MCP_URL=https://your-gateway-domain/v1/datto-rmm/mcp

--- a/msp-claude-plugins/kaseya/it-glue/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/it-glue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "itglue",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Claude plugins for IT Glue documentation platform - organizations, assets, passwords, documents",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/it-glue/README.md
+++ b/msp-claude-plugins/kaseya/it-glue/README.md
@@ -122,7 +122,7 @@ IT Glue operates in multiple regions:
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `ITGLUE_MCP_URL` to your gateway's IT Glue endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `ITGLUE_MCP_URL` to your gateway's IT Glue endpoint:
 
 
 

--- a/msp-claude-plugins/kaseya/rocketcyber/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/rocketcyber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketcyber",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Claude plugins for RocketCyber managed SOC - incidents, agents, accounts, threat detection",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/rocketcyber/README.md
+++ b/msp-claude-plugins/kaseya/rocketcyber/README.md
@@ -47,7 +47,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `ROCKETCYBER_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `ROCKETCYBER_MCP_URL` to your gateway's endpoint:
 
 ```
 ROCKETCYBER_MCP_URL=https://your-gateway-domain/v1/rocketcyber/mcp
@@ -93,7 +93,7 @@ curl -s "https://api-${ROCKETCYBER_REGION:-us}.rocketcyber.com/v3/accounts" \
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/kaseya/rocketcyber

--- a/msp-claude-plugins/liongard/liongard/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/liongard/liongard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liongard",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claude plugins for Liongard - environments, inspections, systems, detections, agents",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/liongard/liongard/README.md
+++ b/msp-claude-plugins/liongard/liongard/README.md
@@ -74,7 +74,7 @@ curl -s "https://${LIONGARD_INSTANCE}.app.liongard.com/api/v1/environments/count
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/liongard/liongard

--- a/msp-claude-plugins/mailprotector/mailprotector/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/mailprotector/mailprotector/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mailprotector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude plugins for Mailprotector email security - CloudFilter quarantine triage, allow/block rules, customer and domain onboarding, user syncs, and mail-flow log analysis for MSPs",
   "author": {
     "name": "WYRE Technology"

--- a/msp-claude-plugins/mailprotector/mailprotector/README.md
+++ b/msp-claude-plugins/mailprotector/mailprotector/README.md
@@ -60,7 +60,7 @@ Use the [MCP Gateway](https://conduit.wyre.ai) to connect — paste your API key
 
 ### Self-Hosted (Docker)
 
-Run the Mailprotector MCP server (`ghcr.io/wyre-technology/mailprotector-mcp`) with the environment variables above. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
+Run the Mailprotector MCP server (`ghcr.io/WYRE-AI/mailprotector-mcp`) with the environment variables above. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ## Available Skills
 

--- a/msp-claude-plugins/mcp-servers/datto-rmm-mcp/README.md
+++ b/msp-claude-plugins/mcp-servers/datto-rmm-mcp/README.md
@@ -14,7 +14,7 @@ MCP server for Datto RMM, enabling Claude to interact with your Datto RMM accoun
 
 ### Via MCP Gateway (Recommended)
 
-This server is designed to work with the [MCP Gateway](https://github.com/wyre-technology/mcp-gateway) which handles authentication and credential management.
+This server is designed to work with the [MCP Gateway](https://github.com/WYRE-AI/mcp-gateway) which handles authentication and credential management.
 
 ### Local Development
 

--- a/msp-claude-plugins/mcp-servers/halopsa-mcp/README.md
+++ b/msp-claude-plugins/mcp-servers/halopsa-mcp/README.md
@@ -16,7 +16,7 @@ MCP server for HaloPSA, enabling Claude to interact with your HaloPSA instance.
 
 ### Via MCP Gateway (Recommended)
 
-This server is designed to work with the [MCP Gateway](https://github.com/wyre-technology/mcp-gateway) which handles authentication and credential management.
+This server is designed to work with the [MCP Gateway](https://github.com/WYRE-AI/mcp-gateway) which handles authentication and credential management.
 
 ### Local Development
 

--- a/msp-claude-plugins/meraki/meraki/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/meraki/meraki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude plugins for Cisco Meraki - Dashboard API v1 network management, organization/network/device inventory, wireless (MR), switching (MS), security appliance (MX) firewall & VPN, camera/sensor (MV/MT) access, live troubleshooting tools, and client policy management for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/meraki/meraki/README.md
+++ b/msp-claude-plugins/meraki/meraki/README.md
@@ -47,7 +47,7 @@ The MCP server defaults to `READ_ONLY_MODE=true`. In read-only mode, curated wri
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `MERAKI_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `MERAKI_MCP_URL` to your gateway's endpoint:
 
 ```
 MERAKI_MCP_URL=https://your-gateway-domain/v1/meraki/mcp

--- a/msp-claude-plugins/ncentral/ncentral/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ncentral/ncentral/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ncentral",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "N-able N-central RMM \u2014 devices, org units, active issues, scheduled tasks, custom properties for on-prem and hosted servers",
   "author": {
     "name": "WYRE Technology"

--- a/msp-claude-plugins/ncentral/ncentral/README.md
+++ b/msp-claude-plugins/ncentral/ncentral/README.md
@@ -20,10 +20,10 @@ N-able N-central is an RMM platform used by MSPs to monitor and manage customer 
 
 ## Installation
 
-Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technology/msp-claude-plugins):
+Install via the [MSP Claude Plugins marketplace](https://github.com/WYRE-AI/msp-claude-plugins):
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install ncentral
 ```
 

--- a/msp-claude-plugins/netsuite/netsuite/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/netsuite/netsuite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "netsuite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude plugin for Oracle NetSuite ERP — records, reports, saved searches, and SuiteQL queries (read-only)",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/netsuite/netsuite/README.md
+++ b/msp-claude-plugins/netsuite/netsuite/README.md
@@ -86,7 +86,7 @@ client** — `.mcp.json` declares only the gateway URL:
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install netsuite
 ```
 

--- a/msp-claude-plugins/ninjaone/ninjaone-rmm/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ninjaone/ninjaone-rmm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ninjaone",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude Code plugin for NinjaOne (NinjaRMM) - devices, organizations, alerts, tickets",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/ninjaone/ninjaone-rmm/README.md
+++ b/msp-claude-plugins/ninjaone/ninjaone-rmm/README.md
@@ -5,7 +5,7 @@ Claude Code plugin for NinjaOne Remote Monitoring and Management.
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins --plugin ninjaone-rmm
+/plugin marketplace add WYRE-AI/msp-claude-plugins --plugin ninjaone-rmm
 ```
 
 ## Configuration
@@ -23,7 +23,7 @@ Get credentials from **Administration > Apps > API** in NinjaOne.
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `NINJAONE_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `NINJAONE_MCP_URL` to your gateway's endpoint:
 
 ```
 NINJAONE_MCP_URL=https://your-gateway-domain/v1/ninjaone/mcp
@@ -85,5 +85,5 @@ NINJAONE_MCP_URL=https://your-gateway-domain/v1/ninjaone/mcp
 
 ## Related
 
-- [MCP Server](https://github.com/wyre-technology/ninjaone-mcp) - Full API access via MCP
+- [MCP Server](https://github.com/WYRE-AI/ninjaone-mcp) - Full API access via MCP
 - [Node Library](https://github.com/asachs01/node-ninjaone) - TypeScript client library

--- a/msp-claude-plugins/nutanix/nutanix/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/nutanix/nutanix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nutanix",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Claude plugins for Nutanix - Prism Central v4 API infrastructure management via the official Nutanix MCP server: VM inventory, cluster operations, storage, networking, and AIOps capacity insight",
   "author": {
     "name": "WYRE Technology"

--- a/msp-claude-plugins/nutanix/nutanix/README.md
+++ b/msp-claude-plugins/nutanix/nutanix/README.md
@@ -71,7 +71,7 @@ done.
 ### Self-Hosted
 
 Run the official [ntnx-api-mcp-server](https://github.com/nutanix/ntnx-api-mcp-server)
-behind the self-hosted [mcp-gateway](https://github.com/wyre-technology/mcp-gateway).
+behind the self-hosted [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway).
 See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup.
 
 ## Available Skills

--- a/msp-claude-plugins/ops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ops-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ops-pack",
   "displayName": "MSP Operations",
   "description": "Cross-vendor service-desk operations \u2014 board health, dispatch prioritization, SLA monitoring, and shift handoffs across whatever PSA/RMM you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/ops-pack/README.md
+++ b/msp-claude-plugins/ops-pack/README.md
@@ -49,7 +49,7 @@ explicitly rather than guessing.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install ops-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/pagerduty/pagerduty/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/pagerduty/pagerduty/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Claude plugins for PagerDuty - incident management, on-call scheduling, service health monitoring, alert management, and analytics for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/pagerduty/pagerduty/README.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/README.md
@@ -36,7 +36,7 @@ export PAGERDUTY_API_TOKEN="your-api-token"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `PAGERDUTY_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `PAGERDUTY_MCP_URL` to your gateway's endpoint:
 
 ```
 PAGERDUTY_MCP_URL=https://your-gateway-domain/v1/pagerduty/mcp

--- a/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Claude plugin for PostHog product analytics — insights, dashboards, feature flags, cohorts, events (read-only)",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/posthog/posthog/README.md
+++ b/msp-claude-plugins/posthog/posthog/README.md
@@ -64,7 +64,7 @@ client** — `.mcp.json` declares only the gateway URL:
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install posthog
 ```
 

--- a/msp-claude-plugins/rootly/rootly/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/rootly/rootly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rootly",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Claude plugins for Rootly - incident management, response automation, postmortems, service catalog, alert routing, and workflow orchestration",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/rootly/rootly/README.md
+++ b/msp-claude-plugins/rootly/rootly/README.md
@@ -35,7 +35,7 @@ export ROOTLY_API_TOKEN="your-api-token"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `ROOTLY_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `ROOTLY_MCP_URL` to your gateway's endpoint:
 
 ```
 ROOTLY_MCP_URL=https://your-gateway-domain/v1/rootly/mcp

--- a/msp-claude-plugins/runzero/runzero/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/runzero/runzero/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "runzero",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude plugins for RunZero - asset discovery, network scanning, service inventory, OS fingerprinting, wireless detection, and vulnerability reporting for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/runzero/runzero/README.md
+++ b/msp-claude-plugins/runzero/runzero/README.md
@@ -36,7 +36,7 @@ export RUNZERO_API_TOKEN="your-account-api-token"
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `RUNZERO_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `RUNZERO_MCP_URL` to your gateway's endpoint:
 
 ```
 RUNZERO_MCP_URL=https://your-gateway-domain/v1/runzero/mcp

--- a/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-alerts",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "SaaS Alerts - SaaS security monitoring and alerting for M365 / Google Workspace: alerts, events, anomaly detection, and multi-tenant response",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/saas-alerts/saas-alerts/README.md
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/README.md
@@ -17,7 +17,7 @@ Claude Code plugin for [SaaS Alerts](https://saasalerts.com) — SaaS security m
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install saas-alerts
 ```
 

--- a/msp-claude-plugins/sales-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/sales-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "sales-pack",
   "displayName": "Sales & Deal Desk",
   "description": "Cross-vendor sales pipeline operations \u2014 deal health, quote-to-close tracking, proposal follow-up, and warm-lead routing across whatever CRM, proposal, distribution, and scheduling tools you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/sales-pack/README.md
+++ b/msp-claude-plugins/sales-pack/README.md
@@ -114,7 +114,7 @@ This marketplace already ships several pieces of sales-relevant tooling.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install sales-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/salesbuildr/salesbuildr/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "salesbuildr",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Claude plugins for Salesbuildr CRM - companies, contacts, products, opportunities, quotes",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/salesbuildr/salesbuildr/README.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/README.md
@@ -5,7 +5,7 @@ CRM plugin for Salesbuildr - manage companies, contacts, products, opportunities
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins --plugin salesbuildr
+/plugin marketplace add WYRE-AI/msp-claude-plugins --plugin salesbuildr
 ```
 
 ## Configuration

--- a/msp-claude-plugins/scalepad/scalepad/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/scalepad/scalepad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scalepad",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "ScalePad - asset lifecycle management, warranty services, client engagement roadmaps (Lifecycle Manager), compliance (ControlMap), backup monitoring (Backup Radar), and quoting (Quoter) for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/scalepad/scalepad/README.md
+++ b/msp-claude-plugins/scalepad/scalepad/README.md
@@ -13,7 +13,7 @@ Claude Code plugin for [ScalePad](https://www.scalepad.com) - asset lifecycle ma
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install scalepad
 ```
 

--- a/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "secops-pack",
   "displayName": "Security Operations",
   "description": "Cross-vendor security alert triage and incident response \u2014 normalizes severity, runs containment playbooks, and builds incident timelines across whatever EDR/MDR/SIEM stack you have connected.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/secops-pack/README.md
+++ b/msp-claude-plugins/secops-pack/README.md
@@ -46,7 +46,7 @@ pack reports what it can verify and calls out, explicitly, what it can't.
 ## Install
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install secops-pack@msp-claude-plugins
 ```
 

--- a/msp-claude-plugins/superops/superops-ai/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/superops/superops-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superops",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Claude Code plugin for SuperOps.ai PSA/RMM - tickets, assets, clients, alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/superops/superops-ai/README.md
+++ b/msp-claude-plugins/superops/superops-ai/README.md
@@ -49,7 +49,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `SUPEROPS_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `SUPEROPS_MCP_URL` to your gateway's endpoint:
 
 ```
 SUPEROPS_MCP_URL=https://your-gateway-domain/v1/superops/mcp
@@ -102,7 +102,7 @@ curl -X POST "https://api.superops.ai/graphql" \
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/superops/superops-ai

--- a/msp-claude-plugins/syncro/syncro-msp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/syncro/syncro-msp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syncro",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Claude Code plugin for Syncro MSP - tickets, customers, assets, invoices",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/syncro/syncro-msp/README.md
+++ b/msp-claude-plugins/syncro/syncro-msp/README.md
@@ -47,7 +47,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 
 ## Self-Hosted Gateway
 
-If you run the [mcp-gateway](https://github.com/wyre-technology/mcp-gateway), set `SYNCRO_MCP_URL` to your gateway's endpoint:
+If you run the [mcp-gateway](https://github.com/WYRE-AI/mcp-gateway), set `SYNCRO_MCP_URL` to your gateway's endpoint:
 
 ```
 SYNCRO_MCP_URL=https://your-gateway-domain/v1/syncro/mcp
@@ -92,7 +92,7 @@ curl -s "https://${SYNCRO_SUBDOMAIN}.syncromsp.com/api/v1/me?api_key=${SYNCRO_AP
 
 ```bash
 # Clone the repository
-git clone https://github.com/wyre-technology/msp-claude-plugins.git
+git clone https://github.com/WYRE-AI/msp-claude-plugins.git
 
 # Navigate to plugin
 cd msp-claude-plugins/syncro/syncro-msp

--- a/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threatlocker",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Claude plugins for ThreatLocker - zero-trust application allowlisting, approval request triage, audit log investigation, and computer/group inventory for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/threatlocker/threatlocker/README.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/README.md
@@ -16,10 +16,10 @@ This plugin provides Claude with deep knowledge of ThreatLocker, enabling MSP an
 
 ## Installation
 
-Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technology/msp-claude-plugins):
+Install via the [MSP Claude Plugins marketplace](https://github.com/WYRE-AI/msp-claude-plugins):
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install threatlocker
 ```
 

--- a/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "timezest",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "TimeZest - tech scheduling and appointment booking against ConnectWise / Autotask / Halo PSA tickets for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/timezest/timezest/README.md
+++ b/msp-claude-plugins/timezest/timezest/README.md
@@ -12,7 +12,7 @@ Claude Code plugin for [TimeZest](https://timezest.com) - PSA-coupled customer s
 ## Installation
 
 ```
-/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin marketplace add WYRE-AI/msp-claude-plugins
 /plugin install timezest
 ```
 

--- a/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warmly",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Warmly visitor intelligence - identified website visitors, account-level engagement, and credit balance",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/warmly/warmly/GOVERNANCE.md
+++ b/msp-claude-plugins/warmly/warmly/GOVERNANCE.md
@@ -9,7 +9,7 @@ endorsed by, or sponsored by the vendor.
 > this document.** `warmly` has no entry in Conduit's
 > `src/credentials/vendor-config.ts` — not a hidden one, not a disabled one,
 > none at all. The connector is wired only in the older
-> `wyre-technology/mcp-gateway` registry (`warmly:` in that repo's own
+> `WYRE-AI/mcp-gateway` registry (`warmly:` in that repo's own
 > `src/credentials/vendor-config.ts`), a separate system this marketplace has
 > otherwise moved off. There is no `warmly` slug to reach at
 > `https://conduit.wyre.ai/v1/mcp`, so a connect attempt there 404s.

--- a/msp-claude-plugins/warmly/warmly/README.md
+++ b/msp-claude-plugins/warmly/warmly/README.md
@@ -2,7 +2,7 @@
 
 Claude Code plugin for [Warmly](https://www.warmly.ai) — visitor intelligence and account-level engagement for B2B sales teams.
 
-> **Not currently brokered by Conduit.** Every other connector in this marketplace reaches its vendor through the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`). Warmly does not: Conduit's `src/credentials/vendor-config.ts` has no `warmly` entry, so there is no slug to connect and a connect attempt 404s. The connector is wired only in the older `wyre-technology/mcp-gateway` registry, described below.
+> **Not currently brokered by Conduit.** Every other connector in this marketplace reaches its vendor through the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`). Warmly does not: Conduit's `src/credentials/vendor-config.ts` has no `warmly` entry, so there is no slug to connect and a connect attempt 404s. The connector is wired only in the older `WYRE-AI/mcp-gateway` registry, described below.
 >
 > This plugin ships no `.mcp.json`, so it wires no client anywhere and nothing is silently misrouted. Its skills and tool reference are accurate about Warmly's API and are why it remains listed — but treat the connection instructions below as describing the legacy system, not the one the rest of this marketplace targets. See `GOVERNANCE.md` for what that means for identity, audit, and revocation.
 
@@ -36,7 +36,7 @@ WARMLY_ORGANIZATION_ID=          # optional; multi-org accounts only
 
 ## Connecting via the legacy WYRE MCP Gateway
 
-Warmly is a first-party connector on the older WYRE MCP Gateway (`mcp.wyre.ai`, the `wyre-technology/mcp-gateway` repo) and **only** there — see the note at the top of this file. Connect Warmly in that gateway's UI: it proxies tool calls to `https://opps-api.getwarmly.com/api/mcp`, handles the AuthKit OAuth dance per tenant, and injects `X-Warmly-Organization-Id` automatically when the field is set.
+Warmly is a first-party connector on the older WYRE MCP Gateway (`mcp.wyre.ai`, the `WYRE-AI/mcp-gateway` repo) and **only** there — see the note at the top of this file. Connect Warmly in that gateway's UI: it proxies tool calls to `https://opps-api.getwarmly.com/api/mcp`, handles the AuthKit OAuth dance per tenant, and injects `X-Warmly-Organization-Id` automatically when the field is set.
 
 Do not substitute `conduit.wyre.ai` in these steps. Conduit has no `warmly` slug, and a per-vendor path for a slug it does not know 404s while looking correct.
 

--- a/msp-claude-plugins/wyre-gateway/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/wyre-gateway/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "wyre-gateway",
   "displayName": "Wyre MSP Gateway",
   "description": "Access all connected MSP tools (Autotask, IT Glue, Datto RMM, etc.) through a single authenticated gateway",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/wyre-gateway/GOVERNANCE.md
+++ b/msp-claude-plugins/wyre-gateway/GOVERNANCE.md
@@ -14,11 +14,11 @@ the per-vendor documents** at the end.
 
 ## Which system this describes, and a naming problem
 
-**Claims here are grounded in `wyre-technology/conduit`**, which serves
+**Claims here are grounded in `WYRE-AI/conduit`**, which serves
 `https://conduit.wyre.ai/v1/mcp`. Conduit is the product.
 
 An earlier revision of this document was written against
-`wyre-technology/mcp-gateway`, which serves `mcp.wyre.ai`. Those are two
+`WYRE-AI/mcp-gateway`, which serves `mcp.wyre.ai`. Those are two
 separate repositories that share ancestry and have since drifted, and
 several of that revision's findings turned out to describe only the older
 system. This revision re-derives every claim from Conduit's source and
@@ -453,7 +453,7 @@ Its real limits, and one genuine strength:
 
 ### 4. Revocation that revokes — holds, with one residual gap
 
-This section was rewritten against `wyre-technology/conduit#1303` (merged
+This section was rewritten against `WYRE-AI/conduit#1303` (merged
 2026-08-06), which closed most of what an earlier revision listed here as
 four exceptions. Two of the four — unrevoked refresh tokens, and a
 `users.active` flag nothing read — are simply gone. One, the unrevocable
@@ -649,7 +649,7 @@ Several can take a site off the network — replacing a firewall ruleset or
 changing an uplink port is not a routine update — and the annotation
 saying so was precisely the part not enforced.
 
-Fixed in `wyre-technology/meraki-mcp#3` (merged 2026-08-04): all six are
+Fixed in `WYRE-AI/meraki-mcp#3` (merged 2026-08-04): all six are
 now gated, and a surface-wide test asserts every tool annotated
 `destructiveHint: true` both declares `confirm_destructive_action` and is
 refused without it. The enumeration was the wrong fix — the PR originally
@@ -732,7 +732,7 @@ correctly:
 | `meraki_raw_request` | 1496 | `isWrite`, `isAdmin` | **admin** |
 
 **`meraki_raw_request` was the one outlier, and it has been fixed**
-(`wyre-technology/conduit#1274`, merged 2026-08-04). It was `isWrite`
+(`WYRE-AI/conduit#1274`, merged 2026-08-04). It was `isWrite`
 only, so a `write`-tier caller could issue arbitrary Meraki API calls —
 including the DELETEs that `meraki_networks_delete` and
 `meraki_devices_remove` pin to `admin` twelve lines above it — and no


### PR DESCRIPTION
Post-migration doc sync. Updates live GitHub references (clone URLs, marketplace install commands, connector repo links) across root docs and ~50 connector READMEs to the WYRE-AI org. The still-unmoved @wyre-technology npm package scope and dated PRD drafts intentionally left as-is. — scribe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/msp-claude-plugins/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790476112&installation_model_id=431408&pr_number=227&repository=WYRE-AI%2Fmsp-claude-plugins&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fmsp-claude-plugins%2Fpull%2F227&signature=a1bca3e3aeece8c79d0b6308bcf357ed54647df96427f066701b36dbde8df25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->