### PR TITLE
docs: fix stale plugin-count claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then restart Claude Code. That's it.
 
 ## What you get
 
-Thirty-three vendor-specific plugins with domain knowledge for PSA, RMM, documentation, security, accounting, CRM, and productivity tools:
+83 vendor-specific plugins with domain knowledge for PSA, RMM, documentation, security, accounting, CRM, and productivity tools — the count keeps growing, so treat [`marketplace.json`](.claude-plugin/marketplace.json) as the source of truth and [mcp.wyre.ai](https://mcp.wyre.ai) as the browsable catalog. The table below highlights the most commonly used integrations, not the full list:
 
 | Plugin | Description |
 |--------|-------------|
@@ -55,6 +55,8 @@ Thirty-three vendor-specific plugins with domain knowledge for PSA, RMM, documen
 Plus shared skills for MSP terminology, ticket triage, cross-vendor incident correlation, and billing reconciliation.
 
 ### Plugin Maturity
+
+Maturity status for the plugins listed above (not the full catalog — see [`marketplace.json`](.claude-plugin/marketplace.json) for all 83):
 
 | Plugin | Status | MCP Server |
 |--------|--------|------------|


### PR DESCRIPTION
## What
The README's "What you get" intro and "Plugin Maturity" heading claimed "Thirty-three" plugins while `marketplace.json` — the file `/plugin marketplace add` actually installs — has 83. Both tables were introduced early and never grown past their original 33 rows.

## Fix
Rather than hand-expanding two README tables to 83 rows (which would just go stale again at 84), reframed both as a highlighted subset and pointed to `marketplace.json` / mcp.wyre.ai as the canonical, always-current source.

Closes #209 (reported by an automated site-monitoring bot — the finding was accurate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/msp-claude-plugins/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790709132&installation_model_id=431408&pr_number=229&repository=WYRE-AI%2Fmsp-claude-plugins&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fmsp-claude-plugins%2Fpull%2F229&signature=03b55375a42c3d6fcd0f1f595cbfbe5c4d9e6b3d3b53263a5210afefa43f5f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->